### PR TITLE
Webアプリケーションログのパーサー変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ ALBとCloudFrontそれぞれで利用します。
 ### 14. ALB作成
 
 ### 15. ECS作成
+設定は正しいのに下記エラーが出る場合があります。
+> reading ECS Task Definition (web): ClientException: Unable to describe task definition.
+
+その場合は、一旦stateを削除すると問題が解説することがあります。
+> terraform state rm module.production.aws_ecs_task_definition.web
 
 ### 16. CodeDeploy作成
 

--- a/modules/main/ecs.tf
+++ b/modules/main/ecs.tf
@@ -131,6 +131,7 @@ resource "aws_ecs_task_definition" "web" {
       firehose_delivery_stream_web_app              = aws_kinesis_firehose_delivery_stream.ecs_container_logs_web_app.name
       firehose_delivery_stream_web_server           = aws_kinesis_firehose_delivery_stream.ecs_container_logs_web_server.name
       web_extra_conf                                = aws_s3_object.web_extra.arn
+      web_app_log_parser_conf                       = aws_s3_object.web_app_log_parser.arn
       nginx_access_log_parser_conf                  = aws_s3_object.nginx_access_log_parser.arn
       nginx_error_log_parser_conf                   = aws_s3_object.nginx_error_log_parser.arn
       cloudwatch_log_group_firelens                 = aws_cloudwatch_log_group.firelens.name

--- a/modules/main/files/conf/fluent-bit/nginx_access_log_parser.conf
+++ b/modules/main/files/conf/fluent-bit/nginx_access_log_parser.conf
@@ -12,3 +12,4 @@
     Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +(?<protocol>[^ ]*))?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")(?: "(?<forwarded_for>[^\"]*)")?
     Time_Key time
     Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Keep On

--- a/modules/main/files/conf/fluent-bit/nginx_error_log_parser.conf
+++ b/modules/main/files/conf/fluent-bit/nginx_error_log_parser.conf
@@ -5,4 +5,4 @@
     Time_Key time
     Time_Format %Y/%m/%d %H:%M:%S
     Time_Offset +09:00
-    Time_Format_Out %Y-%m-%dT%H:%M:%S%z
+    Time_Keep On

--- a/modules/main/files/conf/fluent-bit/web_app_log_parser.conf
+++ b/modules/main/files/conf/fluent-bit/web_app_log_parser.conf
@@ -1,0 +1,6 @@
+[PARSER]
+    Name web_app
+    Format json
+    Time_Key time
+    Time_Format %Y-%m-%dT%H:%M:%S.%3N%z
+    Time_Keep On

--- a/modules/main/files/conf/fluent-bit/web_extra.conf
+++ b/modules/main/files/conf/fluent-bit/web_extra.conf
@@ -8,7 +8,6 @@
 # Under the hood: FireLens for Amazon ECS Tasks - My experience using FireLens: reliability and recommendations
 # https://aws.amazon.com/jp/blogs/containers/under-the-hood-firelens-for-amazon-ecs-tasks/
 [SERVICE]
-    Parsers_File /fluent-bit/parsers/parsers.conf
     HTTP_Server On
     HTTP_Listen 0.0.0.0
     HTTP_PORT 2020
@@ -62,12 +61,19 @@
     Name parser
     Match ${CONTAINER_NAME_WEB_APP}-firelens-*
     Key_Name log
-    Parser json
+    Parser web_app
     Preserve_Key False
     Reserve_Data True
 
 
-# エラーログはCloudWatch Logsに送信したいためにタグを付与します。
+# ログのtimeキーはoriginal_timeキーにリネームして保持します。
+[FILTER]
+    Name modify
+    Match *
+    Rename time original_time
+
+
+# エラーログはCloudWatch Logsにも送信したいためにタグを付与します。
 [FILTER]
     Name rewrite_tag
     Match_Regex ^(stdout|stderr)\.${CONTAINER_NAME_WEB_SERVER}-firelens-.*
@@ -106,5 +112,5 @@
     delivery_stream ${FIREHOSE_DELIVERY_STREAM_WEB_SERVER}
     region ${AWS_REGION}
     time_key time
-    time_key_format %Y-%m-%dT%H:%M:%S%z
+    time_key_format %Y-%m-%dT%H:%M:%S.%3N%z
     compression gzip

--- a/modules/main/files/json/task_definitions/web.json.tpl
+++ b/modules/main/files/json/task_definitions/web.json.tpl
@@ -126,10 +126,14 @@
         },
         {
           "name": "aws_fluent_bit_init_s3_2",
-          "value": "${nginx_access_log_parser_conf}"
+          "value": "${web_app_log_parser_conf}"
         },
         {
           "name": "aws_fluent_bit_init_s3_3",
+          "value": "${nginx_access_log_parser_conf}"
+        },
+        {
+          "name": "aws_fluent_bit_init_s3_4",
           "value": "${nginx_error_log_parser_conf}"
         }
     ],

--- a/modules/main/s3.tf
+++ b/modules/main/s3.tf
@@ -134,6 +134,14 @@ resource "aws_s3_object" "web_extra" {
   etag   = filemd5("${path.module}/files/conf/fluent-bit/web_extra.conf")
 }
 
+resource "aws_s3_object" "web_app_log_parser" {
+  bucket = aws_s3_bucket.fluent_bit_config.bucket
+  key    = "web_app_log_parser.conf"
+  source = "${path.module}/files/conf/fluent-bit/web_app_log_parser.conf"
+
+  etag   = filemd5("${path.module}/files/conf/fluent-bit/web_app_log_parser.conf")
+}
+
 resource "aws_s3_object" "nginx_access_log_parser" {
   bucket = aws_s3_bucket.fluent_bit_config.bucket
   key    = "nginx_access_log_parser.conf"


### PR DESCRIPTION
- JSONパーサーは独自パーサーを利用するように変更します。  
→ fluentbitに同梱されているパーサーでは `Time_Format` がフィットしないことと、 `time` キーは残しておきたいためです。 
- `time` キーは `original_time` に変更し削除しないようにする（実際のログの時間とfirehoseの処理時間を分離するためです）