### PR TITLE
ECSコンテナのイメージ周りを改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,14 +193,42 @@ ECS - Batch
 - コンテナに入るコマンド
 ```
 aws ecs execute-command --region {region} \
-    --cluster {cluster name} \
-    --task {ecs task arn} \
-    --container {container name} \
-    --interactive \
-    --command "/bin/sh"
+  --cluster {cluster name} \
+  --task {ecs task arn} \
+  --container {container name} \
+  --interactive \
+  --command "/bin/sh"
 ```
 
-- バッチ実行コマンド
+- バッチ実行コマンドサンプル
 ```
-aws batch submit-job --job-name test --job-definition batch-default --job-queue batch-default
+aws batch submit-job \
+  --job-name example1 \
+  --job-definition batch-default \
+  --job-queue batch-default \
+  --ecs-properties-override '{
+    "taskProperties": [{
+      "containers": [{
+        "name": "batch-default",
+        "command": ["bundle", "exec", "rake", "test[hoge,fuga]"]
+      }]
+    }]
+  }'
+
+aws batch submit-job \
+  --job-name example2 \
+  --job-definition batch-default \
+  --job-queue batch-default \
+  --ecs-properties-override '{
+    "taskProperties": [{
+      "containers": [{
+        "name": "batch-default",
+        "command": ["bash", "-c", "${COMMAND}"],
+        "environment": [{
+          "name": "COMMAND",
+          "value": "bundle exec rake test[hoge,fuga]"
+        }]
+      }]
+    }]
+  }'
 ```

--- a/modules/main/batch.tf
+++ b/modules/main/batch.tf
@@ -11,7 +11,7 @@ resource "aws_batch_job_definition" "batch_default" {
       task_role_arn                           = aws_iam_role.batch_ecs_task.arn
       region                                  = data.aws_region.current.name
       container_name_batch                    = local.container_names.batch_default
-      batch_image                             = "${aws_ecr_repository.batch_default.repository_url}:dummy"
+      batch_image                             = "${aws_ecr_repository.batch_default.repository_url}:${local.latest_batch_default_tag}"
       cloudwatch_log_group_ecs_container_logs = aws_cloudwatch_log_group.ecs_container_logs.name
       vcpu                                    = var.ecs.task_definition.vcpu
       memory                                  = var.ecs.task_definition.memory
@@ -34,13 +34,13 @@ resource "aws_batch_compute_environment" "batch_default" {
   compute_resources {
     type      = "FARGATE"
     max_vcpus = 16
-    subnets = tolist(aws_subnet.privates[*].id)
+    subnets   = tolist(aws_subnet.privates[*].id)
     security_group_ids = [
       aws_security_group.batch.id
     ]
   }
 
-  depends_on   = [aws_iam_role_policy_attachment.batch_service]
+  depends_on = [aws_iam_role_policy_attachment.batch_service]
 }
 
 resource "aws_batch_job_queue" "batch_default" {
@@ -52,4 +52,19 @@ resource "aws_batch_job_queue" "batch_default" {
     order               = 1
     compute_environment = aws_batch_compute_environment.batch_default.arn
   }
+}
+
+data "external" "latest_batch_default_tag" {
+  program = [
+    "aws", "ecr", "describe-images",
+    "--repository-name", aws_ecr_repository.batch_default.name,
+    "--no-paginate",
+    "--query", "{\"tag\": to_string(sort_by(imageDetails[?imageTags != `null`], &imagePushedAt)[-1].imageTags[0])}"
+  ]
+
+  depends_on = [aws_ecr_repository.batch_default]
+}
+
+locals {
+  latest_batch_default_tag = data.external.latest_batch_default_tag.result.tag != "null" ? data.external.latest_batch_default_tag.result.tag : "dummy"
 }

--- a/modules/main/ecs.tf
+++ b/modules/main/ecs.tf
@@ -124,9 +124,10 @@ resource "aws_ecs_task_definition" "web" {
       container_name_web_app                        = local.container_names.web_app
       container_name_web_server                     = local.container_names.web_server
       container_name_log_router                     = local.container_names.log_router
-      web_app_image                                 = "${aws_ecr_repository.web_app.repository_url}:dummy"
-      web_server_image                              = "${aws_ecr_repository.web_server.repository_url}:dummy"
-      log_router_image                              = "public.ecr.aws/aws-observability/aws-for-fluent-bit:init-latest"
+      web_app_image                                 = "${aws_ecr_repository.web_app.repository_url}:${local.latest_web_app_tag}"
+      web_server_image                              = "${aws_ecr_repository.web_server.repository_url}:${local.latest_web_server_tag}"
+      # 特定のバージョンではSIGSEGVを受信しコンテナが落ちることがありました。将来的にイメージのバージョンアップで再びコンテナが落ちることもありえるためバージョンを固定します。
+      log_router_image                              = "public.ecr.aws/aws-observability/aws-for-fluent-bit:init-amd64-2.32.2.20241003"
       cloudwatch_log_group_ecs_container_error_logs = aws_cloudwatch_log_group.ecs_container_error_logs.name
       firehose_delivery_stream_web_app              = aws_kinesis_firehose_delivery_stream.ecs_container_logs_web_app.name
       firehose_delivery_stream_web_server           = aws_kinesis_firehose_delivery_stream.ecs_container_logs_web_server.name
@@ -155,4 +156,34 @@ resource "aws_ecs_task_definition" "web" {
   lifecycle {
     ignore_changes = all
   }
+}
+
+data "external" "latest_web_app_tag" {
+  program = [
+    "aws", "ecr", "describe-images",
+    "--repository-name", aws_ecr_repository.web_app.name,
+    "--no-paginate",
+    "--query", "{\"tag\": to_string(sort_by(imageDetails[?imageTags != `null`], &imagePushedAt)[-1].imageTags[0])}"
+  ]
+
+  depends_on = [aws_ecr_repository.web_app]
+}
+
+data "external" "latest_web_server_tag" {
+  program = [
+    "aws", "ecr", "describe-images",
+    "--repository-name", aws_ecr_repository.web_server.name,
+    "--no-paginate",
+    "--query", "{\"tag\": to_string(sort_by(imageDetails[?imageTags != `null`], &imagePushedAt)[-1].imageTags[0])}"
+  ]
+
+  depends_on = [aws_ecr_repository.web_server]
+}
+
+locals {
+  latest_web_app_tag = data.external.latest_web_app_tag.result.tag != "null" ? data.external.latest_web_app_tag.result.tag : "dummy"
+}
+
+locals {
+  latest_web_server_tag = data.external.latest_web_server_tag.result.tag != "null" ? data.external.latest_web_server_tag.result.tag : "dummy"
 }

--- a/modules/main/iam.tf
+++ b/modules/main/iam.tf
@@ -110,12 +110,12 @@ data "aws_iam_policy_document" "batch_ecs_task" {
 }
 
 resource "aws_iam_role" "ecs_task_execution" {
-  name                = "ecs-task-execution"
+  name = "ecs-task-execution"
   managed_policy_arns = [
     "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
     aws_iam_policy.parameter_store_secrets_manager_read.arn
   ]
-  assume_role_policy  = data.aws_iam_policy_document.ecs_tasks_assume_role.json
+  assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume_role.json
 }
 
 resource "aws_iam_policy" "parameter_store_secrets_manager_read" {
@@ -244,9 +244,9 @@ data "aws_iam_policy_document" "batch_service_assume_role" {
 }
 
 resource "aws_iam_role" "rds_monitoring" {
-  name                 = "rds-monitoring"
-  managed_policy_arns  = ["arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"]
-  assume_role_policy   = data.aws_iam_policy_document.monitoring_rds_assume_role.json
+  name                = "rds-monitoring"
+  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"]
+  assume_role_policy  = data.aws_iam_policy_document.monitoring_rds_assume_role.json
 }
 
 data "aws_iam_policy_document" "monitoring_rds_assume_role" {
@@ -264,9 +264,9 @@ data "aws_iam_policy_document" "monitoring_rds_assume_role" {
 }
 
 resource "aws_iam_role" "git_hub_actions_oidc" {
-  name                 = "git-hub-actions-oidc"
-  managed_policy_arns  = [aws_iam_policy.git_hub_actions_deploy.arn]
-  assume_role_policy   = data.aws_iam_policy_document.github_actions_oidc_assume_role.json
+  name                = "git-hub-actions-oidc"
+  managed_policy_arns = [aws_iam_policy.git_hub_actions_deploy.arn]
+  assume_role_policy  = data.aws_iam_policy_document.github_actions_oidc_assume_role.json
 }
 
 resource "aws_iam_policy" "git_hub_actions_deploy" {
@@ -421,9 +421,9 @@ data "aws_iam_policy_document" "sns_topic" {
 }
 
 resource "aws_iam_role" "cloud_watch_logs_export" {
-  name                 = "cloud-watch-logs-export"
-  managed_policy_arns  = [aws_iam_policy.cloud_watch_logs_export.arn, "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
-  assume_role_policy   = data.aws_iam_policy_document.scheduler_assume_role.json
+  name                = "cloud-watch-logs-export"
+  managed_policy_arns = [aws_iam_policy.cloud_watch_logs_export.arn, "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
+  assume_role_policy  = data.aws_iam_policy_document.scheduler_assume_role.json
 }
 
 resource "aws_iam_policy" "cloud_watch_logs_export" {

--- a/modules/main/s3.tf
+++ b/modules/main/s3.tf
@@ -131,7 +131,7 @@ resource "aws_s3_object" "web_extra" {
   key    = "web_extra.conf"
   source = "${path.module}/files/conf/fluent-bit/web_extra.conf"
 
-  etag   = filemd5("${path.module}/files/conf/fluent-bit/web_extra.conf")
+  etag = filemd5("${path.module}/files/conf/fluent-bit/web_extra.conf")
 }
 
 /*
@@ -150,7 +150,7 @@ resource "aws_s3_object" "web_app_log_parser" {
   key    = "web_app_log_parser.conf"
   source = "${path.module}/files/conf/fluent-bit/web_app_log_parser.conf"
 
-  etag   = filemd5("${path.module}/files/conf/fluent-bit/web_app_log_parser.conf")
+  etag = filemd5("${path.module}/files/conf/fluent-bit/web_app_log_parser.conf")
 }
 
 resource "aws_s3_object" "nginx_access_log_parser" {
@@ -158,7 +158,7 @@ resource "aws_s3_object" "nginx_access_log_parser" {
   key    = "nginx_access_log_parser.conf"
   source = "${path.module}/files/conf/fluent-bit/nginx_access_log_parser.conf"
 
-  etag   = filemd5("${path.module}/files/conf/fluent-bit/nginx_access_log_parser.conf")
+  etag = filemd5("${path.module}/files/conf/fluent-bit/nginx_access_log_parser.conf")
 }
 
 resource "aws_s3_object" "nginx_error_log_parser" {
@@ -166,7 +166,7 @@ resource "aws_s3_object" "nginx_error_log_parser" {
   key    = "nginx_error_log_parser.conf"
   source = "${path.module}/files/conf/fluent-bit/nginx_error_log_parser.conf"
 
-  etag   = filemd5("${path.module}/files/conf/fluent-bit/nginx_error_log_parser.conf")
+  etag = filemd5("${path.module}/files/conf/fluent-bit/nginx_error_log_parser.conf")
 }
 
 resource "aws_s3_bucket" "ecs_container_logs_web_app" {


### PR DESCRIPTION
* FirelensのコンテナがSIGSEGVで突然落ちるために問題のないコンテナイメージのバージョンで固定化
* アプリケーションのイメージは最新を取得するように改良