### PR TITLE
AWSプロバイダー更新とVPCエンドポイント、ElastiCacheの変更

### DIFF
--- a/environments/production/main/.terraform.lock.hcl
+++ b/environments/production/main/.terraform.lock.hcl
@@ -2,25 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.67.0"
-  constraints = "~> 5.67.0"
+  version     = "5.82.2"
+  constraints = "~> 5.82.0"
   hashes = [
-    "h1:8wkuQvQiqjjm2+gQepy6xFBfimGoesKz1BPcVKWvED8=",
-    "zh:1259c8106c0a3fc0ed3b3eb814ab88d6a672e678b533f47d1bbbe3107949f43e",
-    "zh:226414049afd6d334cc16ff5d6cef23683620a9b56da67a21422a113d9cce4ab",
-    "zh:3c89b103aea20ef82a84e889abaeb971cb168de8292b61b34b83e807c40085a9",
-    "zh:3dd88e994fb7d7a6c6eafd3c01393274e4f776021176acea2e980f73fbd4acbc",
-    "zh:487e0dda221c84a20a143904c1cee4e63fce6c5c57c21368ea79beee87b108da",
-    "zh:7693bdcec8181aafcbda2c41c35b1386997e2c92b6f011df058009e4c8b300e1",
-    "zh:82679536250420f9e8e6edfd0fa9a1bab99a7f31fe5f049ac7a2e0d8c287b56f",
-    "zh:8685218dae921740083820c52afa66cdf14cf130539da1efd7d9a78bfb6ade64",
+    "h1:ce6Dw2y4PpuqAPtnQ0dO270dRTmwEARqnfffrE1VYJ8=",
+    "zh:0262fc96012fb7e173e1b7beadd46dfc25b1dc7eaef95b90e936fc454724f1c8",
+    "zh:397413613d27f4f54d16efcbf4f0a43c059bd8d827fe34287522ae182a992f9b",
+    "zh:436c0c5d56e1da4f0a4c13129e12a0b519d12ab116aed52029b183f9806866f3",
+    "zh:4d942d173a2553d8d532a333a0482a090f4e82a2238acf135578f163b6e68470",
+    "zh:624aebc549bfbce06cc2ecfd8631932eb874ac7c10eb8466ce5b9a2fbdfdc724",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:9e553a3ec05eedea779d393447fc316689ba6c4d4d8d569b986898e6dbe58fee",
-    "zh:a36c24acd3c75bac8211fefde58c459778021eb871ff8339be1c26ad8fd67ee1",
-    "zh:ce48bd1e35d6f996f1a09d8f99e8084469b7fec5611e67a50a63e96375b87ebe",
-    "zh:d6c76a24205513725269e4783da14be9648e9086fb621496052f4b37d52d785e",
-    "zh:d95a31745affb178ea48fa8e0be94691a8f7507ea55c0d0a4b6e0a8ef6fcb929",
-    "zh:f061ce59fac1bc425c1092e6647ed4bb1b61824416041b46dbf336e01a63ad89",
+    "zh:9e632dee2dfdf01b371cca7854b1ec63ceefa75790e619b0642b34d5514c6733",
+    "zh:a07567acb115b60a3df8f6048d12735b9b3bcf85ec92a62f77852e13d5a3c096",
+    "zh:ab7002df1a1be6432ac0eb1b9f6f0dd3db90973cd5b1b0b33d2dae54553dfbd7",
+    "zh:bc1ff65e2016b018b3e84db7249b2cd0433cb5c81dc81f9f6158f2197d6b9fde",
+    "zh:bcad84b1d767f87af6e1ba3dc97fdb8f2ad5de9224f192f1412b09aba798c0a8",
+    "zh:cf917dceaa0f9d55d9ff181b5dcc4d1e10af21b6671811b315ae2a6eda866a2a",
+    "zh:d8e90ecfb3216f3cc13ccde5a16da64307abb6e22453aed2ac3067bbf689313b",
+    "zh:d9054e0e40705df729682ad34c20db8695d57f182c65963abd151c6aba1ab0d3",
+    "zh:ecf3a4f3c57eb7e89f71b8559e2a71e4cdf94eea0118ec4f2cb37e4f4d71a069",
   ]
 }
 

--- a/environments/production/main/versions.tf
+++ b/environments/production/main/versions.tf
@@ -2,10 +2,10 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "~> 5.67.0"
+      version               = "~> 5.82.0"
       configuration_aliases = [aws, aws.virginia]
     }
   }
 
-  required_version = ">=1.9.5"
+  required_version = ">=1.10.0"
 }

--- a/modules/main/elasticache.tf
+++ b/modules/main/elasticache.tf
@@ -1,7 +1,7 @@
 resource "aws_elasticache_serverless_cache" "default" {
   count = var.service_suspend_mode ? 0 : 1
 
-  engine = "redis"
+  engine = "valkey"
   name   = "default"
 
   cache_usage_limits {
@@ -16,13 +16,16 @@ resource "aws_elasticache_serverless_cache" "default" {
 
   daily_snapshot_time      = "19:00" # JST 04:00
   kms_key_id               = aws_kms_key.elasticache.arn
-  major_engine_version     = "7"
+  major_engine_version     = "8"
   snapshot_retention_limit = 1
   security_group_ids       = [aws_security_group.elasticache_default.id]
   subnet_ids               = tolist(aws_subnet.privates[*].id)
   user_group_id            = aws_elasticache_user_group.default.id
 }
 
+# aws_elasticache_user_group、aws_elasticache_userは
+# Valkey8であってもengine = "REDIS"で動作する模様です。
+# https://github.com/hashicorp/terraform-provider-aws/issues/40286
 resource "aws_elasticache_user_group" "default" {
   engine        = "REDIS"
   user_group_id = "default"

--- a/modules/main/vpc_endpoint.tf
+++ b/modules/main/vpc_endpoint.tf
@@ -1,4 +1,5 @@
 # --- Gatewayタイプ ----------------------------------------------------------------
+/*
 resource "aws_vpc_endpoint" "s3" {
   count = var.service_suspend_mode ? 0 : 1
 
@@ -11,7 +12,14 @@ resource "aws_vpc_endpoint" "s3" {
   }
 }
 
-resource "aws_vpc_endpoint_route_table_association" "s3" {
+resource "aws_vpc_endpoint_route_table_association" "s3_publics" {
+  count = var.service_suspend_mode ? 0 : length(var.zone_names)
+
+  route_table_id  = aws_route_table.publics[count.index].id
+  vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
+}
+
+resource "aws_vpc_endpoint_route_table_association" "s3_privates" {
   count = var.service_suspend_mode ? 0 : length(var.zone_names)
 
   route_table_id  = aws_route_table.privates[count.index].id
@@ -30,14 +38,23 @@ resource "aws_vpc_endpoint" "dynamodb" {
   }
 }
 
-resource "aws_vpc_endpoint_route_table_association" "dynamodb" {
+resource "aws_vpc_endpoint_route_table_association" "dynamodb_publics" {
+  count = var.service_suspend_mode ? 0 : length(var.zone_names)
+
+  route_table_id  = aws_route_table.publics[count.index].id
+  vpc_endpoint_id = aws_vpc_endpoint.dynamodb[0].id
+}
+
+resource "aws_vpc_endpoint_route_table_association" "dynamodb_privates" {
   count = var.service_suspend_mode ? 0 : length(var.zone_names)
 
   route_table_id  = aws_route_table.privates[count.index].id
   vpc_endpoint_id = aws_vpc_endpoint.dynamodb[0].id
 }
+*/
 
 # --- Interfaceタイプ -------------------------------------------------------------
+/*
 resource "aws_vpc_endpoint" "ecr_api" {
   count = var.service_suspend_mode ? 0 : 1
 
@@ -49,7 +66,7 @@ resource "aws_vpc_endpoint" "ecr_api" {
     aws_security_group.vpc_endpoint_default.id
   ]
 
-  subnet_ids          = tolist(aws_subnet.privates[*].id)
+  subnet_ids          = concat(tolist(aws_subnet.publics[*].id), tolist(aws_subnet.privates[*].id))
   private_dns_enabled = true
 
   tags = {
@@ -68,13 +85,14 @@ resource "aws_vpc_endpoint" "ecr_dkr" {
     aws_security_group.vpc_endpoint_default.id
   ]
 
-  subnet_ids          = tolist(aws_subnet.privates[*].id)
+  subnet_ids          = concat(tolist(aws_subnet.publics[*].id), tolist(aws_subnet.privates[*].id))
   private_dns_enabled = true
 
   tags = {
     Name = "ecr-dkr"
   }
 }
+*/
 
 resource "aws_vpc_endpoint" "elasticache" {
   count = var.service_suspend_mode ? 0 : 1
@@ -87,7 +105,7 @@ resource "aws_vpc_endpoint" "elasticache" {
     aws_security_group.vpc_endpoint_default.id
   ]
 
-  subnet_ids          = tolist(aws_subnet.privates[*].id)
+  subnet_ids          = concat(tolist(aws_subnet.publics[*].id), tolist(aws_subnet.privates[*].id))
   private_dns_enabled = true
 
   tags = {
@@ -106,7 +124,7 @@ resource "aws_vpc_endpoint" "secrets_manager" {
     aws_security_group.vpc_endpoint_default.id
   ]
 
-  subnet_ids          = tolist(aws_subnet.privates[*].id)
+  subnet_ids          = concat(tolist(aws_subnet.publics[*].id), tolist(aws_subnet.privates[*].id))
   private_dns_enabled = true
 
   tags = {
@@ -125,7 +143,7 @@ resource "aws_vpc_endpoint" "ssm" {
     aws_security_group.vpc_endpoint_default.id
   ]
 
-  subnet_ids          = tolist(aws_subnet.privates[*].id)
+  subnet_ids          = concat(tolist(aws_subnet.publics[*].id), tolist(aws_subnet.privates[*].id))
   private_dns_enabled = true
 
   tags = {
@@ -144,7 +162,7 @@ resource "aws_vpc_endpoint" "ssm_messages" {
     aws_security_group.vpc_endpoint_default.id
   ]
 
-  subnet_ids          = tolist(aws_subnet.privates[*].id)
+  subnet_ids          = concat(tolist(aws_subnet.publics[*].id), tolist(aws_subnet.privates[*].id))
   private_dns_enabled = true
 
   tags = {
@@ -163,7 +181,7 @@ resource "aws_vpc_endpoint" "cloud_watch_logs" {
     aws_security_group.vpc_endpoint_default.id
   ]
 
-  subnet_ids          = tolist(aws_subnet.privates[*].id)
+  subnet_ids          = concat(tolist(aws_subnet.publics[*].id), tolist(aws_subnet.privates[*].id))
   private_dns_enabled = true
 
   tags = {
@@ -182,7 +200,7 @@ resource "aws_vpc_endpoint" "firehose" {
     aws_security_group.vpc_endpoint_default.id
   ]
 
-  subnet_ids          = tolist(aws_subnet.privates[*].id)
+  subnet_ids          = concat(tolist(aws_subnet.publics[*].id), tolist(aws_subnet.privates[*].id))
   private_dns_enabled = true
 
   tags = {
@@ -190,6 +208,7 @@ resource "aws_vpc_endpoint" "firehose" {
   }
 }
 
+/*
 resource "aws_vpc_endpoint" "sns" {
   count = var.service_suspend_mode ? 0 : 1
 
@@ -201,13 +220,14 @@ resource "aws_vpc_endpoint" "sns" {
     aws_security_group.vpc_endpoint_default.id
   ]
 
-  subnet_ids          = tolist(aws_subnet.privates[*].id)
+  subnet_ids          = concat(tolist(aws_subnet.publics[*].id), tolist(aws_subnet.privates[*].id))
   private_dns_enabled = true
 
   tags = {
     Name = "sns"
   }
 }
+*/
 
 resource "aws_vpc_endpoint" "sqs" {
   count = var.service_suspend_mode ? 0 : 1
@@ -220,7 +240,7 @@ resource "aws_vpc_endpoint" "sqs" {
     aws_security_group.vpc_endpoint_default.id,
   ]
 
-  subnet_ids          = tolist(aws_subnet.privates[*].id)
+  subnet_ids          = concat(tolist(aws_subnet.publics[*].id), tolist(aws_subnet.privates[*].id))
   private_dns_enabled = true
 
   tags = {


### PR DESCRIPTION
* terraform、 aws providerバージョンアップ
* あまり頻繁にアクセスしないvpcエンドポイントをコメントアウト
* vpcエンドポイントにパブリックサブネット追加
* elasticacheをvalkeyに変更