### PR TITLE
Elasticache Serverless対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,12 @@ terraform import module.production.aws_dynamodb_table.terraform_state_lock terra
 ### 11. SSMパラメータストアでパラメータ登録
 以下をAWSマネジメントコンソールから手動で登録します。
 - `/app/rails/secret_key_base`
-- `/rds/postgres/host` （※ 値はdummyで登録します。リソース作成後に正しいエンドポイントをセットします）
+- `/rds/postgres/host` （※ 値はdummyで登録します。リソース作成後に正しいホストをセットします）
 - `/rds/postgres/user`
 - `/rds/postgres/password`
 - `/rds/postgres/database`
 - `/sqs/queue/default` （※ エンドポイントをセットします）
-- `/elasticache/default/host` （※ 値はdummyで登録します。リソース作成後に正しいエンドポイントをセットします）
+- `/elasticache/default/host` （※ 値はdummyで登録します。リソース作成後に正しいホストをセットします）
 - `/elasticache/default-dummy/password`
 - `/elasticache/default-admin/user`
 - `/elasticache/default-admin/password`
@@ -213,7 +213,7 @@ ECS - Batch
 
 - コンテナに入るコマンド
 ```
-aws ecs execute-command --region {region} \
+aws ecs execute-command --region ap-northeast-1 \
   --cluster {cluster name} \
   --task {ecs task arn} \
   --container {container name} \

--- a/modules/main/files/json/job_definitions/batch_default.json.tpl
+++ b/modules/main/files/json/job_definitions/batch_default.json.tpl
@@ -26,6 +26,18 @@
           ],
           "secrets": [
             {
+              "name": "ELASTICACHE_HOST",
+              "valueFrom": "/elasticache/default/host"
+            },
+            {
+              "name": "ELASTICACHE_USER",
+              "valueFrom": "/elasticache/default-custom/user"
+            },
+            {
+              "name": "ELASTICACHE_PASSWORD",
+              "valueFrom": "/elasticache/default-custom/password"
+            },
+            {
               "name": "POSTGRES_DB",
               "valueFrom": "/rds/postgres/database"
             },

--- a/modules/main/files/json/task_definitions/web.json.tpl
+++ b/modules/main/files/json/task_definitions/web.json.tpl
@@ -43,6 +43,18 @@
     ],
     "secrets": [
       {
+        "name": "ELASTICACHE_HOST",
+        "valueFrom": "/elasticache/default/host"
+      },
+      {
+        "name": "ELASTICACHE_USER",
+        "valueFrom": "/elasticache/default-custom/user"
+      },
+      {
+        "name": "ELASTICACHE_PASSWORD",
+        "valueFrom": "/elasticache/default-custom/password"
+      },
+      {
         "name": "POSTGRES_DB",
         "valueFrom": "/rds/postgres/database"
       },

--- a/modules/main/files/json/task_definitions/worker.json.tpl
+++ b/modules/main/files/json/task_definitions/worker.json.tpl
@@ -18,6 +18,18 @@
     ],
     "secrets": [
       {
+        "name": "ELASTICACHE_HOST",
+        "valueFrom": "/elasticache/default/host"
+      },
+      {
+        "name": "ELASTICACHE_USER",
+        "valueFrom": "/elasticache/default-custom/user"
+      },
+      {
+        "name": "ELASTICACHE_PASSWORD",
+        "valueFrom": "/elasticache/default-custom/password"
+      },
+      {
         "name": "POSTGRES_DB",
         "valueFrom": "/rds/postgres/database"
       },

--- a/modules/main/iam.tf
+++ b/modules/main/iam.tf
@@ -168,6 +168,7 @@ data "aws_iam_policy_document" "parameter_store_secrets_manager_read" {
     ]
     resources = [
       "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/app/*",
+      "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/elasticache/*",
       "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/rds/*",
       "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/sqs/*"
     ]

--- a/modules/main/vpc_endpoint.tf
+++ b/modules/main/vpc_endpoint.tf
@@ -66,7 +66,7 @@ resource "aws_vpc_endpoint" "ecr_api" {
     aws_security_group.vpc_endpoint_default.id
   ]
 
-  subnet_ids          = concat(tolist(aws_subnet.publics[*].id), tolist(aws_subnet.privates[*].id))
+  subnet_ids          = tolist(aws_subnet.privates[*].id)
   private_dns_enabled = true
 
   tags = {
@@ -85,7 +85,7 @@ resource "aws_vpc_endpoint" "ecr_dkr" {
     aws_security_group.vpc_endpoint_default.id
   ]
 
-  subnet_ids          = concat(tolist(aws_subnet.publics[*].id), tolist(aws_subnet.privates[*].id))
+  subnet_ids          = tolist(aws_subnet.privates[*].id)
   private_dns_enabled = true
 
   tags = {
@@ -93,25 +93,6 @@ resource "aws_vpc_endpoint" "ecr_dkr" {
   }
 }
 */
-
-resource "aws_vpc_endpoint" "elasticache" {
-  count = var.service_suspend_mode ? 0 : 1
-
-  vpc_id            = aws_vpc.default.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.elasticache"
-  vpc_endpoint_type = "Interface"
-
-  security_group_ids = [
-    aws_security_group.vpc_endpoint_default.id
-  ]
-
-  subnet_ids          = concat(tolist(aws_subnet.publics[*].id), tolist(aws_subnet.privates[*].id))
-  private_dns_enabled = true
-
-  tags = {
-    Name = "elasticache"
-  }
-}
 
 resource "aws_vpc_endpoint" "secrets_manager" {
   count = var.service_suspend_mode ? 0 : 1
@@ -124,7 +105,7 @@ resource "aws_vpc_endpoint" "secrets_manager" {
     aws_security_group.vpc_endpoint_default.id
   ]
 
-  subnet_ids          = concat(tolist(aws_subnet.publics[*].id), tolist(aws_subnet.privates[*].id))
+  subnet_ids          = tolist(aws_subnet.privates[*].id)
   private_dns_enabled = true
 
   tags = {
@@ -143,7 +124,7 @@ resource "aws_vpc_endpoint" "ssm" {
     aws_security_group.vpc_endpoint_default.id
   ]
 
-  subnet_ids          = concat(tolist(aws_subnet.publics[*].id), tolist(aws_subnet.privates[*].id))
+  subnet_ids          = tolist(aws_subnet.privates[*].id)
   private_dns_enabled = true
 
   tags = {
@@ -162,7 +143,7 @@ resource "aws_vpc_endpoint" "ssm_messages" {
     aws_security_group.vpc_endpoint_default.id
   ]
 
-  subnet_ids          = concat(tolist(aws_subnet.publics[*].id), tolist(aws_subnet.privates[*].id))
+  subnet_ids          = tolist(aws_subnet.privates[*].id)
   private_dns_enabled = true
 
   tags = {
@@ -181,7 +162,7 @@ resource "aws_vpc_endpoint" "cloud_watch_logs" {
     aws_security_group.vpc_endpoint_default.id
   ]
 
-  subnet_ids          = concat(tolist(aws_subnet.publics[*].id), tolist(aws_subnet.privates[*].id))
+  subnet_ids          = tolist(aws_subnet.privates[*].id)
   private_dns_enabled = true
 
   tags = {
@@ -200,7 +181,7 @@ resource "aws_vpc_endpoint" "firehose" {
     aws_security_group.vpc_endpoint_default.id
   ]
 
-  subnet_ids          = concat(tolist(aws_subnet.publics[*].id), tolist(aws_subnet.privates[*].id))
+  subnet_ids          = tolist(aws_subnet.privates[*].id)
   private_dns_enabled = true
 
   tags = {
@@ -220,7 +201,7 @@ resource "aws_vpc_endpoint" "sns" {
     aws_security_group.vpc_endpoint_default.id
   ]
 
-  subnet_ids          = concat(tolist(aws_subnet.publics[*].id), tolist(aws_subnet.privates[*].id))
+  subnet_ids          = tolist(aws_subnet.privates[*].id)
   private_dns_enabled = true
 
   tags = {
@@ -240,7 +221,7 @@ resource "aws_vpc_endpoint" "sqs" {
     aws_security_group.vpc_endpoint_default.id,
   ]
 
-  subnet_ids          = concat(tolist(aws_subnet.publics[*].id), tolist(aws_subnet.privates[*].id))
+  subnet_ids          = tolist(aws_subnet.privates[*].id)
   private_dns_enabled = true
 
   tags = {


### PR DESCRIPTION
* elasticache serverlessではvpcエンドポイントは自動で設定されるために不要
* vpcエンドポイントのサブネット設定でpublicサブネット不要なので削除
* ecsコンテナにelasticacheの情報を環境変数にセット
* ssmパラメータアクセス権限不足追加